### PR TITLE
WS2-459 Plugin for lists.

### DIFF
--- a/js/plugins/websparkliststyle/dialogs/liststyle.js
+++ b/js/plugins/websparkliststyle/dialogs/liststyle.js
@@ -1,0 +1,413 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights
+ *   reserved. For licensing, see LICENSE.md or
+ *   https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+(function () {
+  function getListElement(editor, listTag) {
+    var range;
+    try {
+      range = editor.getSelection().getRanges()[0];
+    }
+    catch (e) {
+      return null;
+    }
+
+    range.shrink(CKEDITOR.SHRINK_TEXT);
+    return editor.elementPath(range.getCommonAncestor()).contains(listTag, 1);
+  }
+
+  var listItem = function (node) {
+    return node.type == CKEDITOR.NODE_ELEMENT && node.is('li');
+  };
+
+  function listStyle(editor, startupPage) {
+    if (startupPage == 'bulletedListStyle') {
+      return {
+        title: 'Bulleted List Properties',
+        minWidth: 300,
+        minHeight: 50,
+        contents: [{
+          id: 'info',
+          accessKey: 'I',
+          elements: [
+            {
+              type: 'select',
+              label: 'Color',
+              id: 'color',
+              align: 'center',
+              style: 'width:150px',
+              items: [
+                ['Default', 'default-list'],
+                ['Maroon', 'maroon'],
+                ['Light Smoke Mode', 'light-smokemode'],
+                ['Smoke Mode', 'smokemode'],
+                ['Dark Mode', 'darkmode'],
+                ['Dark Mode Gold', 'darkmode-gold'],
+                ['Icon list', 'icn-default'],
+                ['Icon list Maroon', 'icn-maroon'],
+                ['Icon list Dark Mode', 'icn-darkmode'],
+                ['Icon list Dark Mode Gold', 'icn-darkmode-gold']
+              ],
+              setup: function (element) {
+                // Always default to default.
+                this.setValue('default-list');
+              },
+              commit: function (element) {
+                // Get select value.
+                var value = this.getValue();
+
+                if (value == '') {
+                  value = 'default-list';
+                }
+
+                // If value starts with icn its a icon list.
+                if (value.startsWith('icn')) {
+
+                  // Alert the user that you cannot step list a multi level list.
+                  var nested_ul = element.$.querySelectorAll("ul");
+                  if (nested_ul.length > 0) {
+                    editor.showNotification( 'Cannot apply style to multi level list' );
+                    return;
+                  }
+
+                  // Add required classes for Icon list.
+                  element.addClass('uds-list');
+                  element.addClass('fa-ul');
+
+                  if (value == 'icn-maroon') {
+                    element.removeClass('darkmode');
+                    element.removeClass('gold');
+                    element.addClass('maroon')
+                  }
+
+                  if (value == 'icn-darkmode') {
+                    element.addClass('darkmode');
+                    element.removeClass('gold');
+                    element.removeClass('maroon')
+                  }
+
+                  if (value == 'icn-darkmode-gold') {
+                    element.addClass('darkmode');
+                    element.addClass('gold');
+                    element.removeClass('maroon')
+                  }
+                }
+
+                // This is as standard bulleted list.
+                else {
+                  // Remove icon class.
+                  element.removeClass('fa-ul')
+
+                  if (element.hasClass('default-list') && value != 'default-list') {
+                    element.removeClass('default-list');
+                  }
+                  if (element.hasClass('default-list') && value != 'default-list') {
+                    element.removeClass('default-list');
+                  }
+                  if (element.hasClass('maroon') && value != 'maroon') {
+                    element.removeClass('maroon');
+                  }
+                  if (element.hasClass('light-smokemode') && value != 'light-smokemode') {
+                    element.removeClass('light-smokemode');
+                  }
+                  if (element.hasClass('smokemode') && value != 'smokemode') {
+                    element.removeClass('smokemode');
+                  }
+                  if (element.hasClass('darkmode') && value != 'darkmode') {
+                    element.removeClass('darkmode');
+                  }
+                  if (element.hasClass('darkmode') && element.hasClass('gold') && value != 'darkmode-gold') {
+                    element.removeClass('darkmode');
+                    element.removeClass('gold');
+                  }
+                  if (value == 'darkmode-gold') {
+                    element.addClass('darkmode');
+                    element.addClass('gold');
+                  }
+                  else {
+                    element.addClass(value);
+                  }
+                }
+                if (!element.hasClass('uds-list')) {
+                  element.addClass('uds-list');
+                }
+              }
+            }
+          ],
+
+        }],
+
+        onShow: function () {
+          var editor = this.getParentEditor(),
+            element = getListElement(editor, 'ul');
+
+          element && this.setupContent(element);
+        },
+        onOk: function () {
+          var editor = this.getParentEditor(),
+            element = getListElement(editor, 'ul');
+
+          element && this.commitContent(element);
+        }
+      };
+    }
+    else if (startupPage == 'numberedListStyle') {
+
+      return {
+        title: 'Numbered List Properties',
+        minWidth: 300,
+        minHeight: 50,
+        contents: [{
+          id: 'info',
+          accessKey: 'I',
+          elements: [{
+            type: 'hbox',
+            widths: ['25%', '75%'],
+            children: [
+              {
+                type: 'select',
+                label: 'Color',
+                id: 'color',
+                align: 'center',
+                style: 'width:150px',
+                items: [
+                  ['Default', 'default-list'],
+                  ['Maroon', 'maroon'],
+                  ['Light Smoke Mode', 'light-smokemode'],
+                  ['Smoke Mode', 'smokemode'],
+                  ['Dark Mode', 'darkmode'],
+                  ['Dark Mode Gold', 'darkmode-gold'],
+                  ['Step List Default', 'stp-default'],
+                  ['Step List Gold Counter', 'stp-gold-counter'],
+                  ['Step List Maroon Counter', 'stp-maroon-counter'],
+                  ['Step List Smokemode', 'stp-smokemode'],
+                  ['Step List Smokemode Gold Counter', 'stp-smokemode-gold'],
+                  ['Step List Smokemode Maroon Counter', 'stp-smokemode-maroon'],
+                  ['Step List Light Smokemode', 'stp-lightsmokemode'],
+                  ['Step List Light Smokemode Gold Counter', 'stp-lightsmokemode-gold'],
+                  ['Step List Light Smokemode Maroon Counter', 'stp-lightsmokemode-maroon'],
+                  ['Step List Darkmode', 'stp-darkmode'],
+                  ['Step List Darkmode Gold Counter', 'stp-darkmode-gold']
+                ],
+                setup: function (element) {
+                  // Always default to default.
+                  this.setValue('default-list');
+                },
+                commit: function (element) {
+                  // Get select value.
+                  var value = this.getValue();
+
+                  if (value == '') {
+                    value = 'default-list';
+                  }
+
+                  // If value starts with stp its a step value.
+                  if (value.startsWith('stp')) {
+
+                    // Alert the user that you cannot step list a multi level list.
+                    var nested_ol = element.$.querySelectorAll("ol");
+                    if (nested_ol.length > 0) {
+                      editor.showNotification( 'Cannot apply style to multi level list' );
+                      return;
+                    }
+
+                    // Add required classes for steplist.
+                    element.addClass('uds-list');
+                    element.addClass('uds-steplist');
+
+
+                    // Remove NLR clases.
+                    if (value == 'stp-default') {
+                      // Remove NLR classes.
+                      element.remove('uds-steplist-gold');
+                      element.remove('uds-steplist-maroon');
+                      element.remove('smokemode');
+                      element.remove('light-smokemode');
+                      element.remove('darkmode');
+                      element.remove('maroon');
+                    }
+                    // Default gold.
+                    if (value == 'stp-gold-counter') {
+                      // Remove NLR classes.
+                      element.remove('uds-steplist-maroon');
+                      element.remove('smokemode');
+                      element.remove('light-smokemode');
+                      element.remove('darkmode');
+
+                      // Add classes.
+                      element.addClass('uds-steplist-gold');
+                    }
+                    // Default maroon.
+                    if (value == 'stp-maroon-counter') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-gold');
+                      element.removeClass('smokemode');
+                      element.removeClass('light-smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('uds-steplist-maroon');
+                    }
+                    // Smoke mode.
+                    if (value == 'stp-smokemode') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-gold');
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('light-smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('smokemode');
+                    }
+                    // Smoke mode gold.
+                    if (value == 'stp-smokemode-gold') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('light-smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('smokemode');
+                      element.addClass('uds-steplist-gold');
+                    }
+                    // Smoke mode maroon.
+                    if (value == 'stp-smokemode-maroon') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('light-smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('smokemode');
+                      element.addClass('uds-steplist-maroon');
+                    }
+                    // Light Smoke mode.
+                    if (value == 'stp-lightsmokemode') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-gold');
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('light-smokemode');
+                    }
+                    // Light Smoke mode gold.
+                    if (value == 'stp-lightsmokemode-gold') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('light-smokemode');
+                      element.addClass('uds-steplist-gold');
+                    }
+                    // Light Smoke mode maroon.
+                    if (value == 'stp-lightsmokemode-maroon') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-gold');
+                      element.removeClass('smokemode');
+                      element.removeClass('darkmode');
+
+                      // Add classes.
+                      element.addClass('light-smokemode');
+                      element.addClass('uds-steplist-maroon');
+                    }
+                    // Darkmode.
+                    if (value == 'stp-darkmode') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-gold');
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('smokemode');
+                      element.removeClass('light-smokemode');
+
+                      // Add classes.
+                      element.addClass('darkmode');
+                    }
+                    // Darkmode gold.
+                    if (value == 'stp-darkmode-gold') {
+                      // Remove NLR classes.
+                      element.removeClass('uds-steplist-maroon');
+                      element.removeClass('smokemode');
+                      element.removeClass('light-smokemode');
+
+                      // Add classes.
+                      element.addClass('darkmode');
+                      element.addClass('uds-steplist-gold');
+                    }
+                  }
+
+                  else {
+                    // Remove step list elements.
+                    element.removeClass('uds-steplist');
+                    element.removeClass('uds-steplist-maroon');
+                    element.removeClass('uds-steplist-gold');
+
+                    // Add class after removing existing class.
+                    if (value) {
+                      // Ensure the step list class is not applied.
+                      element.removeClass('uds-steplist');
+                      // Add remove classes as required.
+                      if (element.hasClass('default-list') && value != 'default-list') {
+                        element.removeClass('default-list');
+                      }
+                      if (element.hasClass('maroon') && value != 'maroon') {
+                        element.removeClass('maroon');
+                      }
+                      if (element.hasClass('light-smokemode') && value != 'light-smokemode') {
+                        element.removeClass('light-smokemode');
+                      }
+                      if (element.hasClass('smokemode') && value != 'smokemode') {
+                        element.removeClass('smokemode');
+                      }
+                      if (element.hasClass('darkmode') && value != 'darkmode') {
+                        element.removeClass('darkmode');
+                      }
+                      if (element.hasClass('darkmode') && element.hasClass('gold') && value != 'darkmode-gold') {
+                        element.removeClass('darkmode');
+                        element.removeClass('gold');
+                      }
+                      if (value == 'darkmode-gold') {
+                        element.addClass('darkmode');
+                        element.addClass('gold');
+                      }
+                      else {
+                        element.addClass(value);
+                      }
+                    }
+                    // Apply uds-list class if element does not have it.
+                    if (!element.hasClass('uds-list')) {
+                      element.addClass('uds-list');
+                    }
+                  }
+                }
+              }]
+          }]
+        }],
+        onShow: function () {
+          var editor = this.getParentEditor(),
+            element = getListElement(editor, 'ol');
+
+          element && this.setupContent(element);
+        },
+        onOk: function () {
+          var editor = this.getParentEditor(),
+            element = getListElement(editor, 'ol');
+
+          element && this.commitContent(element);
+        }
+      };
+    }
+  }
+
+  CKEDITOR.dialog.add('numberedListStyle', function (editor) {
+    return listStyle(editor, 'numberedListStyle');
+  });
+
+  CKEDITOR.dialog.add('bulletedListStyle', function (editor) {
+    return listStyle(editor, 'bulletedListStyle');
+  });
+})();

--- a/js/plugins/websparkliststyle/dialogs/liststyle.js
+++ b/js/plugins/websparkliststyle/dialogs/liststyle.js
@@ -41,14 +41,14 @@
               items: [
                 ['Default', 'default-list'],
                 ['Maroon', 'maroon'],
-                ['Light Smoke Mode', 'light-smokemode'],
-                ['Smoke Mode', 'smokemode'],
-                ['Dark Mode', 'darkmode'],
-                ['Dark Mode Gold', 'darkmode-gold'],
+                ['Gray 1', 'light-smokemode'],
+                ['Gray 2', 'smokemode'],
+                ['Gray 7', 'darkmode'],
+                ['Gray 7 Gold Bullet', 'darkmode-gold'],
                 ['Icon list', 'icn-default'],
                 ['Icon list Maroon', 'icn-maroon'],
-                ['Icon list Dark Mode', 'icn-darkmode'],
-                ['Icon list Dark Mode Gold', 'icn-darkmode-gold']
+                ['Icon list Gray 7', 'icn-darkmode'],
+                ['Icon list Gray 7 Gold', 'icn-darkmode-gold']
               ],
               setup: function (element) {
                 // Always default to default.
@@ -57,6 +57,11 @@
               commit: function (element) {
                 // Get select value.
                 var value = this.getValue();
+                // Alert the user that they cannot theme lists within a list.
+                if ( element.$.parentElement.nodeName === 'LI' ) {
+                  editor.showNotification( 'Cannot apply more than one style to multi level list' );
+                  return;
+                }
 
                 if (value == '') {
                   value = 'default-list';
@@ -175,21 +180,21 @@
                 items: [
                   ['Default', 'default-list'],
                   ['Maroon', 'maroon'],
-                  ['Light Smoke Mode', 'light-smokemode'],
-                  ['Smoke Mode', 'smokemode'],
-                  ['Dark Mode', 'darkmode'],
-                  ['Dark Mode Gold', 'darkmode-gold'],
+                  ['Gray 1', 'light-smokemode'],
+                  ['Gray 2', 'smokemode'],
+                  ['Gray 7', 'darkmode'],
+                  ['Gray 7 Gold', 'darkmode-gold'],
                   ['Step List Default', 'stp-default'],
                   ['Step List Gold Counter', 'stp-gold-counter'],
                   ['Step List Maroon Counter', 'stp-maroon-counter'],
-                  ['Step List Smokemode', 'stp-smokemode'],
-                  ['Step List Smokemode Gold Counter', 'stp-smokemode-gold'],
-                  ['Step List Smokemode Maroon Counter', 'stp-smokemode-maroon'],
-                  ['Step List Light Smokemode', 'stp-lightsmokemode'],
-                  ['Step List Light Smokemode Gold Counter', 'stp-lightsmokemode-gold'],
-                  ['Step List Light Smokemode Maroon Counter', 'stp-lightsmokemode-maroon'],
-                  ['Step List Darkmode', 'stp-darkmode'],
-                  ['Step List Darkmode Gold Counter', 'stp-darkmode-gold']
+                  ['Step List Gray 2', 'stp-smokemode'],
+                  ['Step List Gray 2 Gold Counter', 'stp-smokemode-gold'],
+                  ['Step List Gray 2 Maroon Counter', 'stp-smokemode-maroon'],
+                  ['Step List Gray 1', 'stp-lightsmokemode'],
+                  ['Step List Gray 1 Gold Counter', 'stp-lightsmokemode-gold'],
+                  ['Step List Gray 1 Maroon Counter', 'stp-lightsmokemode-maroon'],
+                  ['Step List Gray 7', 'stp-darkmode'],
+                  ['Step List Gray 7 Gold Counter', 'stp-darkmode-gold']
                 ],
                 setup: function (element) {
                   // Always default to default.
@@ -198,6 +203,12 @@
                 commit: function (element) {
                   // Get select value.
                   var value = this.getValue();
+
+                  // Alert the user that they cannot theme lists within a list.
+                  if ( element.$.parentElement.nodeName === 'LI' ) {
+                    editor.showNotification( 'Cannot apply more than one style to multi level list' );
+                    return;
+                  }
 
                   if (value == '') {
                     value = 'default-list';

--- a/js/plugins/websparkliststyle/plugin.js
+++ b/js/plugins/websparkliststyle/plugin.js
@@ -1,0 +1,62 @@
+﻿( function() {
+  CKEDITOR.plugins.liststyle = {
+    requires: 'dialog,contextmenu',
+    init: function( editor ) {
+      if ( editor.blockless )
+        return;
+
+      var def, cmd;
+
+      def = new CKEDITOR.dialogCommand( 'numberedListStyle', {
+        requiredContent: 'ol',
+        allowedContent: 'ol',
+      } );
+      cmd = editor.addCommand( 'numberedListStyle', def );
+      editor.addFeature( cmd );
+      CKEDITOR.dialog.add( 'numberedListStyle', this.path + 'dialogs/liststyle.js' );
+
+      def = new CKEDITOR.dialogCommand( 'bulletedListStyle', {
+        requiredContent: 'ul',
+        allowedContent: 'ul',
+      } );
+      cmd = editor.addCommand( 'bulletedListStyle', def );
+      editor.addFeature( cmd );
+      CKEDITOR.dialog.add( 'bulletedListStyle', this.path + 'dialogs/liststyle.js' );
+
+      //Register map group;
+      editor.addMenuGroup( 'list', 108 );
+
+      editor.addMenuItems( {
+        numberedlist: {
+          label: 'Numbered List Properties',
+          group: 'list',
+          command: 'numberedListStyle'
+        },
+        bulletedlist: {
+          label: 'Bulleted List Properties',
+          group: 'list',
+          command: 'bulletedListStyle'
+        }
+      } );
+
+      editor.contextMenu.addListener( function( element ) {
+        if ( !element || element.isReadOnly() )
+          return null;
+
+        while ( element ) {
+          var name = element.getName();
+          if ( name == 'ol' )
+            return { numberedlist: CKEDITOR.TRISTATE_OFF };
+          else if ( name == 'ul' )
+            return { bulletedlist: CKEDITOR.TRISTATE_OFF };
+
+          element = element.getParent();
+        }
+        return null;
+      } );
+    },
+
+  };
+
+  CKEDITOR.plugins.add( 'liststyle', CKEDITOR.plugins.liststyle );
+} )();

--- a/src/Plugin/CKEditorPlugin/WebsparkListStyle.php
+++ b/src/Plugin/CKEditorPlugin/WebsparkListStyle.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\webspark_ckeditor_plugins\Plugin\CKEditorPlugin;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\editor\Entity\Editor;
+use Drupal\ckeditor\CKEditorPluginInterface;
+use Drupal\ckeditor\CKEditorPluginContextualInterface;
+
+/**
+ * Defines the "List Style" plugin.
+ *
+ * @CKEditorPlugin(
+ *   id = "liststyle",
+ *   label = @Translation("List Style")
+ * )
+ */
+class WebsparkListStyle extends PluginBase implements CKEditorPluginInterface, CKEditorPluginContextualInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getButtons() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEnabled(Editor $editor) {
+    $enabled = FALSE;
+    $settings = $editor->getSettings();
+    foreach ($settings['toolbar']['rows'] as $row) {
+      foreach ($row as $group) {
+        foreach ($group['items'] as $button) {
+          if (($button === 'BulletedList') || ($button === 'NumberedList')) {
+            $enabled = TRUE;
+          }
+        }
+      }
+    }
+
+    return $enabled;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isInternal() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDependencies(Editor $editor) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLibraries(Editor $editor) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFile() {
+
+    $plugin = FALSE;
+
+    // Get plugin path.
+    $plugin_path = drupal_get_path('module', 'webspark_ckeditor_plugins') . '/js/plugins/websparkliststyle/plugin.js';
+
+    if (file_exists(DRUPAL_ROOT . '/' . $plugin_path)) {
+      $plugin = $plugin_path;
+    }
+
+    return $plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig(Editor $editor) {
+    return [];
+  }
+
+}


### PR DESCRIPTION
This plugin provides contextual menus for Bulleted and Ordered Lists. Right clicking on a list fires a contextual menu which gives options depending on the type of list. Multi level lists do not support some styling options, so a message is displayed explaining this.

This plugin relies on updates to Lists in the theme which have already been deployed to RC2 and a PR is available on the Renovation theme also.