### PR TITLE
Fix js error.

### DIFF
--- a/js/plugins/websparkhighlightedheading/plugin.js
+++ b/js/plugins/websparkhighlightedheading/plugin.js
@@ -35,7 +35,11 @@ CKEDITOR.plugins.add('websparkhighlightedheading', {
                 // Get heading type
                 this.data.headingtype = jQuery('h1,h2,h3,h4,h5', $el).prop("tagName").toLowerCase();
                 // Get text
-                this.data.content = editor.getSelection().getSelectedText();
+                if (editor.getSelection()) {
+                    this.data.content = editor.getSelection().getSelectedText();
+                } else {
+                    this.data.content = jQuery('span', $el).text();
+                }
                 
             },
 


### PR DESCRIPTION
Fix a js error "Uncaught TypeError: editor.getSelection() is null" that occurs when editing content.