### PR TITLE
WS2-1082: Fix Webspark table plugin.

### DIFF
--- a/src/Plugin/CKEditorPlugin/WebsparkTable.php
+++ b/src/Plugin/CKEditorPlugin/WebsparkTable.php
@@ -26,31 +26,10 @@ class WebsparkTable extends CKEditorPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function getLibraries(Editor $editor) {
-    return [];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfig(Editor $editor) {
     return [];
   }
 
-  /**
-  * {@inheritdoc}
-  */
-  public function getDependencies(Editor $editor) {
-    
-  }
-
-  /**
-  * {@inheritdoc}
-  */
-  public function isInternal() {
-    
-  }
-  
   /**
    * {@inheritdoc}
    */


### PR DESCRIPTION
@duarte-daniela @mlsamuelson @ovista-dept this removes the extra methods as they are defined in the CKEditorPluginBase class. 
This also fixes the warning messages related to getDependencies() method not returning a value.